### PR TITLE
Update Builder

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -210,7 +210,7 @@ namespace DatabaseFactory {
          *
          * @return array|null
          */
-        public function get(): ?array
+        private function get(): ?array
         {
             return $this->execute()->fetchAll(\PDO::FETCH_ASSOC);
         }


### PR DESCRIPTION
Made `get()` private so that it may only be accessed by the Builder class.