### PR TITLE
ORM Changes

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -4,7 +4,8 @@ namespace DatabaseFactory {
 
     use ReflectionClass;
     use ReflectionProperty;
-    use DatabaseFactory\Facades;
+	use DatabaseFactory\ORM;
+	use DatabaseFactory\Facades;
 
     /**
      * The base entity class
@@ -20,7 +21,8 @@ namespace DatabaseFactory {
     class Entity
     {
         // ORM Plugins
-        use \DatabaseFactory\ORM\HasTable;
+        use ORM\HasTable;
+        use ORM\HasQuery;
 
         /**
          * ID of a record for updating

--- a/src/ORM/HasAll.php
+++ b/src/ORM/HasAll.php
@@ -17,9 +17,9 @@ namespace DatabaseFactory\ORM {
      */
     trait HasAll
     {
-        public static function all(string $columns = '*'): Builder
+        public static function all(string $columns = '*')
         {
-            return Facades\DB::table(static::table())->select($columns);
+            return Facades\DB::table(static::table())->select($columns)->get();
         }
     }
 }

--- a/src/ORM/HasFind.php
+++ b/src/ORM/HasFind.php
@@ -17,9 +17,9 @@ namespace DatabaseFactory\ORM {
      */
     trait HasFind
     {
-        public static function find(int $id, string $columns = '*'): Builder
+        public static function find(int|string $value, string $by = 'id', string $columns = '*')
         {
-            return Facades\DB::table(static::table())->select($columns)->where('id', '=', $id);
+            return Facades\DB::table(static::table())->select($columns)->where($by, '=', $value)->get();
         }
     }
 }

--- a/src/ORM/HasFirst.php
+++ b/src/ORM/HasFirst.php
@@ -19,9 +19,9 @@ namespace DatabaseFactory\ORM {
      */
     trait HasFirst
     {
-        public static function first(string $columns = '*'): Builder
+        public static function first(string $columns = '*')
         {
-            return Facades\DB::table(static::table())->select($columns)->orderBy('id', 'ASC')->limit(1);
+            return Facades\DB::table(static::table())->select($columns)->orderBy('id', 'ASC')->limit(1)->get();
         }
     }
 }

--- a/src/ORM/HasJoin.php
+++ b/src/ORM/HasJoin.php
@@ -17,9 +17,9 @@ namespace DatabaseFactory\ORM {
      */
     trait HasJoin
     {
-        public static function join(string $table, array $on, string $columns = '*'): Builder
+        public static function join(string $table, array $on, string $columns = '*')
         {
-            return Facades\DB::table(static::table())->join($table, $on, $columns);
+            return Facades\DB::table(static::table())->join($table, $on, $columns)->get();
         }
     }
 }

--- a/src/ORM/HasLast.php
+++ b/src/ORM/HasLast.php
@@ -19,9 +19,9 @@ namespace DatabaseFactory\ORM {
      */
     trait HasLast
     {
-        public static function last(string $columns = '*'): Builder
+        public static function last(string $columns = '*')
         {
-            return Facades\DB::table(static::table())->select($columns)->orderBy('id', 'DESC')->limit(1);
+            return Facades\DB::table(static::table())->select($columns)->orderBy('id', 'DESC')->limit(1)->get();
         }
     }
 }

--- a/src/ORM/HasLike.php
+++ b/src/ORM/HasLike.php
@@ -17,9 +17,9 @@ namespace DatabaseFactory\ORM {
      */
     trait HasLike
     {
-        public static function like(string $field, string $pattern, string $columns = '*'): Builder
+        public static function like(string $field, string $pattern, string $columns = '*')
         {
-            return Facades\DB::table(static::table())->select($columns)->like($field, $pattern);
+            return Facades\DB::table(static::table())->select($columns)->like($field, $pattern)->get();
         }
     }
 }

--- a/src/ORM/HasNot.php
+++ b/src/ORM/HasNot.php
@@ -18,9 +18,9 @@ namespace DatabaseFactory\ORM {
      */
     trait HasNot
     {
-        public static function whereNot($key = null, $value = null, string $columns = '*'): Builder
+        public static function whereNot($key = null, $value = null, string $columns = '*')
         {
-            return Facades\DB::table(static::table())->select($columns)->whereNot($key, $value);
+            return Facades\DB::table(static::table())->select($columns)->whereNot($key, $value)->get();
         }
     }
 }

--- a/src/ORM/HasQuery.php
+++ b/src/ORM/HasQuery.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace DatabaseFactory\ORM {
+	
+	use DatabaseFactory\Config;
+	use DatabaseFactory\Facades;
+	use DatabaseFactory\Builder;
+	
+	trait HasQuery
+	{
+		public static function query(string $config = Config::class): Builder
+		{
+			return Facades\DB::table(static::table(), $config);
+		}
+	}
+}

--- a/src/ORM/HasWhere.php
+++ b/src/ORM/HasWhere.php
@@ -19,9 +19,9 @@ namespace DatabaseFactory\ORM {
      */
     trait HasWhere
     {
-        public static function where($key, $is = null, $value = null, string $columns = '*'): Builder
+        public static function where($key, $is = null, $value = null, string $columns = '*')
         {
-            return Facades\DB::table(static::table())->select($columns)->where($key, $is, $value);
+            return Facades\DB::table(static::table())->select($columns)->where($key, $is, $value)->get();
         }
     }
 }


### PR DESCRIPTION
 - All ORM traits (except HasQuery) now return a collection of data instead of the `Builder` instead of a new Builder instance.
 - The `HasQuery` ORM trait has been introduced, to return a new `Builder` instance on the current entity class.